### PR TITLE
Add more usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ void loop() {
 
 Upload the sketch and ask Alexa to discover devices.
 
+### Additional Examples
+
+Other sketches in the `examples` folder demonstrate different device types:
+
+* `onoff-light` – uses **AsyncEspAlexaOnOffDevice**
+* `dimmable-light` – uses **AsyncEspAlexaDimmableDevice**
+* `white-spectrum-light` – uses **AsyncEspAlexaWhiteSpectrumDevice**
+* `extended-color-light` – uses **AsyncEspAlexaExtendedColorDevice**
+* `before-state-update` – shows `beforeStateUpdateCallback` to sync hardware state
+
 ## Modules
 
 ### 1. `AsyncEspAlexaColorUtils`

--- a/examples/before-state-update/BeforeStateUpdate.ino
+++ b/examples/before-state-update/BeforeStateUpdate.ino
@@ -1,0 +1,49 @@
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include "async_esp_alexa_manager.hh"
+
+const char* ssid = "Your_SSID";
+const char* password = "Your_PASSWORD";
+
+AsyncEspAlexaManager alexaManager;
+AsyncWebServer server(80);
+
+constexpr uint8_t SWITCH_PIN = 2; // Example output pin
+
+void syncState(AsyncEspAlexaDevice* device) {
+  auto* light = static_cast<AsyncEspAlexaOnOffDevice*>(device);
+  bool state = digitalRead(SWITCH_PIN);
+  light->setOn(state);
+}
+
+void onPowerChanged(bool on) {
+  digitalWrite(SWITCH_PIN, on ? HIGH : LOW);
+  Serial.printf("[Device] ON: %d\n", on);
+}
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(SWITCH_PIN, OUTPUT);
+
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\nWiFi connected!");
+
+  auto* light = new AsyncEspAlexaOnOffDevice("Synced Light", false);
+  light->setOnOffCallback(onPowerChanged);
+  light->setBeforeStateUpdateCallback(syncState);
+
+  alexaManager.reserve(1);
+  alexaManager.addDevice(light);
+  alexaManager.begin();
+
+  server.addHandler(alexaManager.createAlexaAsyncWebHandler());
+  server.begin();
+}
+
+void loop() {
+  alexaManager.loop();
+}

--- a/examples/dimmable-light/DimmableLight.ino
+++ b/examples/dimmable-light/DimmableLight.ino
@@ -1,0 +1,38 @@
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include "async_esp_alexa_manager.hh"
+
+const char* ssid = "Your_SSID";
+const char* password = "Your_PASSWORD";
+
+AsyncEspAlexaManager alexaManager;
+AsyncWebServer server(80);
+
+void onBrightnessChanged(bool on, uint8_t bri) {
+  Serial.printf("[Device] ON: %d, Brightness: %u\n", on, bri);
+  // analogWrite() or other PWM control can be used here
+}
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\nWiFi connected!");
+
+  auto* light = new AsyncEspAlexaDimmableDevice("Dimmable Light", true, 128);
+  light->setBrightnessCallback(onBrightnessChanged);
+
+  alexaManager.reserve(1);
+  alexaManager.addDevice(light);
+  alexaManager.begin();
+
+  server.addHandler(alexaManager.createAlexaAsyncWebHandler());
+  server.begin();
+}
+
+void loop() {
+  alexaManager.loop();
+}

--- a/examples/extended-color-light/ExtendedColorLight.ino
+++ b/examples/extended-color-light/ExtendedColorLight.ino
@@ -1,0 +1,47 @@
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include "async_esp_alexa_manager.hh"
+#include "async_esp_alexa_color_utils.hh"
+
+const char* ssid = "Your_SSID";
+const char* password = "Your_PASSWORD";
+
+AsyncEspAlexaManager alexaManager;
+AsyncWebServer server(80);
+
+void onCtChanged(bool on, uint8_t bri, uint16_t ct) {
+  Serial.printf("[CT] ON:%d Bri:%u CT:%u\n", on, bri, ct);
+}
+
+void onColorChanged(bool on, uint8_t bri, uint16_t hue, uint8_t sat) {
+  Serial.printf("[HSV] ON:%d Bri:%u Hue:%u Sat:%u\n", on, bri, hue, sat);
+  auto rgb = AsyncEspAlexaColorUtils::hsvToRgb(hue, sat, bri);
+  Serial.printf("[RGB] R:%u G:%u B:%u\n", rgb[0], rgb[1], rgb[2]);
+}
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\nWiFi connected!");
+
+  using Device = AsyncEspAlexaExtendedColorDevice;
+  auto* light = new Device(
+    "Extended Light", true, 128, 30000, 200, 370, Device::ColorMode::ct);
+  light->setColorCallback(onColorChanged);
+  light->setColorTemperatureCallback(onCtChanged);
+
+  alexaManager.reserve(1);
+  alexaManager.addDevice(light);
+  alexaManager.begin();
+
+  server.addHandler(alexaManager.createAlexaAsyncWebHandler());
+  server.begin();
+}
+
+void loop() {
+  alexaManager.loop();
+}

--- a/examples/onoff-light/OnOffLight.ino
+++ b/examples/onoff-light/OnOffLight.ino
@@ -1,0 +1,42 @@
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include "async_esp_alexa_manager.hh"
+
+const char* ssid = "Your_SSID";
+const char* password = "Your_PASSWORD";
+
+AsyncEspAlexaManager alexaManager;
+AsyncWebServer server(80);
+
+constexpr uint8_t LIGHT_PIN = 2; // Built-in LED on many boards
+
+void onPowerChanged(bool on) {
+  Serial.printf("[Device] ON: %d\n", on);
+  digitalWrite(LIGHT_PIN, on ? HIGH : LOW);
+}
+
+void setup() {
+  Serial.begin(115200);
+  pinMode(LIGHT_PIN, OUTPUT);
+
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\nWiFi connected!");
+
+  auto* light = new AsyncEspAlexaOnOffDevice("Simple Light", false);
+  light->setOnOffCallback(onPowerChanged);
+
+  alexaManager.reserve(1);
+  alexaManager.addDevice(light);
+  alexaManager.begin();
+
+  server.addHandler(alexaManager.createAlexaAsyncWebHandler());
+  server.begin();
+}
+
+void loop() {
+  alexaManager.loop();
+}

--- a/examples/white-spectrum-light/WhiteSpectrumLight.ino
+++ b/examples/white-spectrum-light/WhiteSpectrumLight.ino
@@ -1,0 +1,40 @@
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include "async_esp_alexa_manager.hh"
+#include "async_esp_alexa_color_utils.hh"
+
+const char* ssid = "Your_SSID";
+const char* password = "Your_PASSWORD";
+
+AsyncEspAlexaManager alexaManager;
+AsyncWebServer server(80);
+
+void onWhiteChanged(bool on, uint8_t bri, uint16_t ct) {
+  Serial.printf("[Device] ON: %d, Brightness: %u, CT: %u\n", on, bri, ct);
+  auto rgb = AsyncEspAlexaColorUtils::ctToRgb(bri, ct);
+  Serial.printf("[RGB] R:%u G:%u B:%u\n", rgb[0], rgb[1], rgb[2]);
+}
+
+void setup() {
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("\nWiFi connected!");
+
+  auto* light = new AsyncEspAlexaWhiteSpectrumDevice("White Light", true, 128, 300);
+  light->setCallback(onWhiteChanged);
+
+  alexaManager.reserve(1);
+  alexaManager.addDevice(light);
+  alexaManager.begin();
+
+  server.addHandler(alexaManager.createAlexaAsyncWebHandler());
+  server.begin();
+}
+
+void loop() {
+  alexaManager.loop();
+}

--- a/include/async_esp_alexa_device.hh
+++ b/include/async_esp_alexa_device.hh
@@ -42,10 +42,6 @@ private:
             beforeStateUpdateCallback(this);
     }
 
-    virtual void setBeforeStateUpdateCallback(const std::function<void(AsyncEspAlexaDevice* device)>& callback)
-    {
-        this->beforeStateUpdateCallback = callback;
-    }
 
     void setId(const uint8_t id)
     {
@@ -102,6 +98,11 @@ public:
     }
 
     virtual ~AsyncEspAlexaDevice() = default;
+
+    void setBeforeStateUpdateCallback(const std::function<void(AsyncEspAlexaDevice* device)>& callback)
+    {
+        this->beforeStateUpdateCallback = callback;
+    }
 
     virtual const char* getType() = 0;
     virtual const char* getModelId() = 0;


### PR DESCRIPTION
## Summary
- expose `setBeforeStateUpdateCallback` publicly
- add examples for on/off, dimmable, white-spectrum and extended color devices
- demonstrate `beforeStateUpdateCallback`
- document examples in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598c8e8cb8832fb77557f89f83ffee